### PR TITLE
Remove OS Specific stuff - perhaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,14 +115,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         src/prototyper
         src/prototyper/fx
 )
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_sources(${PROJECT_NAME} PRIVATE
-        thirdparty/freegetopt/getopt.c
-    )
-    target_include_directories(${PROJECT_NAME} PRIVATE
-        thirdparty/freegetopt/
-    )
-endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
         glfw
@@ -132,13 +124,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         ixwebsocket
         MinimalSocket
 )
-
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_package(X11 REQUIRED)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${X11_INCLUDE_DIR})
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${X11_LIBRARIES})
-endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
         $<$<NOT:$<CONFIG:Debug>>:USE_EMBEDDED_SHADERS>


### PR DESCRIPTION
No clue about the whole CMake subsystem.
"Works on my machine" (Debian Linux 13) without any issues, and as it was introduced as a support measure for Ubuntu - it seems unnecessary, and seems to add some "always on" dependencies (guessed) - and feels unneeded - since glfw already provides flags for disabling either x11 or Wayland.